### PR TITLE
czinspect: implement subsampling ratio scanning and filtering

### DIFF
--- a/src/czinspect/helptxt/extract.help
+++ b/src/czinspect/helptxt/extract.help
@@ -4,6 +4,11 @@ Options:
     -d <dir>    Output directory for extracted data files
     -a          Extract file attachments
     -e          Extract file metadata
+    -f <val>    Extract only those subblock components whose subsampling level
+                is equal to "val"
+    -g          If the subsampling level provided to '-f' is not found in the
+                input file, then round the value down to the nearest subsampling
+                level
     -s <str>    Extract the subblock components specified by the comma seperated
                 list of sections specified in "str"
 

--- a/src/czinspect/helptxt/main.help
+++ b/src/czinspect/helptxt/main.help
@@ -13,7 +13,7 @@ Global options:
                 one time for each file. (This option should only be used on
                 32-bit systems.)
 
-**NOTE**: Only the '-E' operation is implemented at this time!
+**NOTE**: Only the '-E' and '-S' operations are implemented at this time!
 
 Pass '-h' with an operation to see usage information and options specific to
 that operation.

--- a/src/czinspect/helptxt/scan.help
+++ b/src/czinspect/helptxt/scan.help
@@ -1,3 +1,3 @@
 Usage: czinspect -S [options] <file>
 
-This operation does not have any options, and is currently unimplemented.
+This operation does not have any options.

--- a/src/czinspect/src/alloc.c
+++ b/src/czinspect/src/alloc.c
@@ -38,7 +38,7 @@ char *_xstrdup(const char *name, char *str) {
 static void* (*volatile lzmemset)(void *, int, size_t) = memset;
 
 lzstring _lzstr_new(const char *name, size_t num, size_t sz) {
-    lzstring ret = malloc(sizeof(lzstring));
+    lzstring ret = malloc(sizeof(struct lzstring_s));
     if (ret == NULL)
         nerr1(name, "could not allocate dynamic string");
 

--- a/src/czinspect/src/czinspect.c
+++ b/src/czinspect/src/czinspect.c
@@ -32,7 +32,7 @@
 #define GETOPT_OPS    "SEDCh"
 
 #define GETOPT_S_STR  ""
-#define GETOPT_E_STR  "ad:es:"
+#define GETOPT_E_STR  "ad:ef:gs:"
 #define GETOPT_D_STR  "o:"
 #define GETOPT_C_STR  ""
 
@@ -151,6 +151,9 @@ static void parse_opt_scan(int opt) {
 
 /* process extraction options */
 static void parse_opt_extract(int opt) {
+    const char *errstr;
+    uint16_t filt;
+    
     switch (opt) {
     case 'a':
         cfg.eflags |= EXT_F_ATTACH;
@@ -160,6 +163,16 @@ static void parse_opt_extract(int opt) {
         break;
     case 'e':
         cfg.eflags |= EXT_F_META;
+        break;
+    case 'f':
+        filt = strtonum((const char *) optarg, 1, UINT16_MAX, &errstr);
+        if (errstr)
+            errx(1, "invalid filter level '%s': %s", optarg, errstr);
+        cfg.filter = filt;
+        cfg.eflags |= EXT_F_FILT;
+        break;
+    case 'g':
+        cfg.eflags |= EXT_F_FFUZZ;
         break;
     case 's':
         cfg.eflags |= EXT_F_SBLK;

--- a/src/czinspect/src/operations.c
+++ b/src/czinspect/src/operations.c
@@ -3,10 +3,6 @@
 
 #include "types.h"
 
-void do_scan(struct config *cfg) {
-    return;
-}
-    
 void do_dump(struct config *cfg) {
     return;
 }

--- a/src/czinspect/src/operations.h
+++ b/src/czinspect/src/operations.h
@@ -7,6 +7,8 @@
 #define EXT_F_META   0x01
 #define EXT_F_ATTACH 0x02
 #define EXT_F_SBLK   0x04
+#define EXT_F_FILT   0x08
+#define EXT_F_FFUZZ  0x10 /* round the extraction level */
 
 void do_scan(struct config *);
 void do_extract(struct config *);

--- a/src/czinspect/src/scan.c
+++ b/src/czinspect/src/scan.c
@@ -1,0 +1,65 @@
+
+#include "config.h"
+
+#include <err.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "types.h"
+#include "alloc.h"
+#include "macros.h"
+#include "mapfile.h"
+#include "util.h"
+#include "zeiss.h"
+#include "zeissio.h"
+
+static void parse_opts(struct config *cfg) {
+    /* currently a nop */
+    (void)cfg;
+    return;
+}
+
+void do_scan(struct config *cfg) {
+    struct czi_seg_header head;
+    struct czi_zrf zisrf;
+    struct map_ctx *c;
+    lzbuf reslist;
+    uint32_t rnum = 0;
+
+    parse_opts(cfg);
+
+    c = cfg->inctx;
+
+        /* read initial segment */
+    if (czi_read_sh(c, &head) == -1)
+        ferrx1("could not read initial segment header from input file");
+
+    if (czi_getsegid(&head) != ZISRAWFILE)
+        ferrx1("input file does not start with a ZISRAWFILE segment");
+
+    if (czi_read_zrf(c, &zisrf) == -1)
+        ferrx1("could not read ZISRAWFILE segment");
+
+    /* XXX this should be changed when segment-local scanning is implemented */
+    if (zisrf.directory_position == 0)
+        ferrx1("file contains no subblock directory, cannot scan for subsampling levels");
+
+    if (map_seek(c, zisrf.directory_position, MAP_SET) == -1)
+        ferrx("could not seek to offset %" PRIu64 " to read subblock directory", zisrf.directory_position);
+
+    reslist = lzbuf_new(uint32_t);
+
+    if (make_reslist(c, reslist, &rnum) == -1)
+        ferrx1("could not scan for subsampling levels in input file");
+
+    printf("Available subsampling levels (smaller number indicates higher resolution):\n\n");
+
+    for (uint32_t i = 0; i < rnum; i++)
+        printf("\t%" PRIu32 "\n", lzbuf_get(uint32_t, reslist, i));
+
+    printf("\n");
+    lzbuf_free(reslist);
+    
+    return;
+}

--- a/src/czinspect/src/types.h
+++ b/src/czinspect/src/types.h
@@ -32,6 +32,7 @@ struct config {
     /* extraction options */
     char *outdir;
     uint8_t eflags;    /* whole-file extraction flags */
+    uint32_t filter;   /* filter level */
     char *esopts;      /* option string for extracting data from subblocks */
 
     /* dumping options */

--- a/src/czinspect/src/util.c
+++ b/src/czinspect/src/util.c
@@ -6,12 +6,18 @@
 #include <sys/types.h>
 #include <err.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "types.h"
+#include "alloc.h"
 #include "macros.h"
 #include "mapfile.h"
+#include "util.h"
+#include "zeiss.h"
+#include "zeissio.h"
 
 #define DEV_ZERO "/dev/zero"
 
@@ -40,5 +46,122 @@ int xfallocate(int fd, size_t sz) {
     }
 
     map_mclose(ctx);
+    return 0;
+}
+
+uint32_t get_subsample_level(lzbuf dims, uint32_t ndims) {
+    /* we only filter on the X and Y dimensions */
+    char x[4] = "X\0\0\0";
+    char y[4] = "Y\0\0\0";
+    uint32_t xratio = 0, yratio = 0;
+    struct czi_subblock_dimentry *entry;
+
+    for (uint32_t i = 0; i < ndims; i++) {
+        entry = &lzbuf_get(struct czi_subblock_dimentry, dims, i);
+        if (memcmp(entry->dimension, x, 4) == 0) {
+            if (xratio) {
+                fwarnx1("directory entry contains duplicate X dimension, skipping dimension");
+                continue;
+            }
+            xratio = czi_subblock_dim_ratio(entry);
+        } else if (memcmp(entry->dimension, y, 4) == 0) {
+            if (yratio) {
+                fwarnx1("directory entry contains duplicate Y dimension, skipping dimension");
+                continue;
+            }
+            yratio = czi_subblock_dim_ratio(entry);
+        }
+    }
+
+    if (xratio == 0) {
+        fwarnx1("directory entry missing X dimension, skipping entry");
+        return 0;
+    }
+
+    if (yratio == 0) {
+        fwarnx1("directory entry missing Y dimension, skipping entry");
+        return 0;
+    }
+
+    if (xratio != yratio) {
+        fwarnx1("directory entry does not have equal X and Y dimensions, skipping entry");
+        return 0;
+    }
+
+    return xratio;
+}
+
+static void scan_res(lzbuf dims, uint32_t ndims, lzbuf ints, uint32_t *nints) {
+    uint32_t res;
+
+    res = get_subsample_level(dims, ndims);
+    if (res == 0)
+        return;
+
+    for (uint32_t i = 0; i < *nints; i++) {
+        if (res == lzbuf_get(uint32_t, ints, i))
+            return;
+    }
+
+    if (*nints >= ints->len)
+        lzbuf_grow(uint32_t, ints);
+
+    lzbuf_get(uint32_t, ints, *nints) = res;
+    *nints += 1;
+    
+    return;
+}
+
+/* scan a .czi file for subsampling levels. the mapping context provided must
+ * point to the beginning of the ZISRAWDIRECTORY segment and the dynamic buffer
+ * will be used for storing uint32_t */
+int make_reslist(struct map_ctx *c, lzbuf list, uint32_t *num) {
+    struct czi_seg_header head;
+    struct czi_directory dir;
+    struct czi_subblock_direntry sdir;
+    struct czi_subblock_dimentry *entry;
+    lzbuf dimensions;
+
+    if (czi_read_sh(c, &head) == -1)
+        return fwarnx1("could not read segment header"), -1;
+
+    if (czi_getsegid(&head) != ZISRAWDIRECTORY)
+        return fwarnx1("incorrect directory segment id"), -1;
+    
+    if (czi_read_directory(c, &dir) == -1)
+        return fwarnx1("could not read directory segment"), -1;
+
+    if (dir.entry_count == 0)
+        return fwarnx1("directory entry segment contains no entries"), -1;
+
+    dimensions = lzbuf_new(struct czi_subblock_dimentry);
+    *num = 0;
+    
+    for (uint32_t i = 0; i < dir.entry_count; i++) {
+        if (czi_read_sblk_direntry(c, &sdir) == -1)
+            return fwarnx("could not read directory entry #%" PRIu32, i + 1), -1;
+
+        if (sdir.dimension_count == 0) {
+            fwarnx("directory entry #%" PRIu32 " has no dimension entries, continuing", i + 1);
+            continue;
+        }
+
+        while (lzbuf_elems(struct czi_subblock_dimentry, dimensions) < sdir.dimension_count)
+            lzbuf_grow(struct czi_subblock_dimentry, dimensions);
+
+        for (uint32_t j = 0; j < sdir.dimension_count; j++) {
+            entry = &lzbuf_get(struct czi_subblock_dimentry, dimensions, j);
+
+            if (czi_read_sblk_dimentry(c, entry) == -1)
+                return fwarnx1("could not read subblock dimension entries"), -1;
+        }
+        
+        scan_res(dimensions, sdir.dimension_count, list, num);
+
+        lzbuf_zero(dimensions);
+    }
+
+    lzbuf_free(dimensions);
+    
     return 0;
 }

--- a/src/czinspect/src/util.h
+++ b/src/czinspect/src/util.h
@@ -4,9 +4,13 @@
 #include <stdint.h>
 
 #include "types.h"
+#include "alloc.h"
 
 #define czi_subblock_dim_ratio(d)    ((d)->stored_size == 0 ? 1 : ((d)->size / (d)->stored_size))
 
 int xfallocate(int, size_t);
+
+uint32_t get_subsample_level(lzbuf, uint32_t);
+int make_reslist(struct map_ctx *, lzbuf, uint32_t *);
 
 #endif /* _UTIL_H */


### PR DESCRIPTION
This also fixes some unpleasant memory corruption issues in the memory allocation logic.