### PR TITLE
czinspect: change endianness detection

### DIFF
--- a/src/czinspect/src/zeissio.c
+++ b/src/czinspect/src/zeissio.c
@@ -21,10 +21,11 @@
             return -1;                                              \
     } while (0)
 
-#ifdef IS_BIG_ENDIAN
-# define SW32(v)  data->v = sw32(data->v)
-# define SW64(v)  data->v = sw64(data->v)
-# define SWF(f)   data->f = swf(data->f)
+#if defined(__BYTE_ORDER__)
+#  if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#    define SW32(v)  data->v = sw32(data->v)
+#    define SW64(v)  data->v = sw64(data->v)
+#    define SWF(f)   data->f = swf(data->f)
 
 static uint32_t sw32(uint32_t v) {
     return ((v & 0xff) << 24) | (((v >> 8) & 0xff) << 16) | (((v >> 16) & 0xff) << 8) | ((v >> 24) & 0xff);
@@ -48,10 +49,15 @@ static float swf(float f) {
     return ret;
 }
 
+#  elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define SW32(v)
+#    define SW64(v)
+#    define SWF(v)
+#  else
+#    error "Your compiler does not expose a __BYTE_ORDER__ macro with a recognised value"
+#  endif
 #else
-# define SW32(v)
-# define SW64(v)
-# define SWF(v)
+#error "Please upgrade to a compiler which exposes the __BYTE_ORDER__ macro"
 #endif
 
 /* read in a segment header */

--- a/src/czinspect/tools/configtest.c
+++ b/src/czinspect/tools/configtest.c
@@ -7,30 +7,21 @@
 /* simple config test program */
 
 /* 
- * this program tests machine byte order and pointer size. we also test if we're
- * compiling on Darwin, as slightly different macros are required to expose recent
- * POSIX functions.
+ * this program tests machine pointer size. we also test if we're compiling on
+ * Darwin, as slightly different macros are required to expose recent POSIX
+ * functions. endianness used to be detected by this program, but there are
+ * standard macros exposed by gcc and clang which can be used to detect
+ * appropriate endianness.
  */
 
 
 int main() {
-    uint32_t u32 = 0x44332211;
-    uint32_t *u32ptr = &u32;
-    unsigned char *cptr = (unsigned char *) u32ptr;
-
     printf("#ifndef _CONFIG_H\n");
     printf("#define _CONFIG_H\n");
 
     /* test address space size */
     if (sizeof(uintptr_t) <= sizeof(uint32_t)) {
         printf("#define SLIDING_MMAP\n");
-    }
-
-    /* test endianness */
-    if (*cptr == 0x44) {
-        printf("#define IS_BIG_ENDIAN\n");
-    } else if (*cptr != 0x11) { /* detect weirdness */
-        errx(1, "could not determine machine endianness");
     }
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Modern GCC and Clang support an inbuilt macro `__BYTE_ORDER__` for reporting the target system's endianness at compile time. This replaces the homebrewed test in the `tools/configtest` program. Note that this requires a reasonably recent compiler (at least GCC 4.9 or so).

I have tested this commit on x86\_64 Linux, x86\_64 OpenBSD and PowerPC G4 OpenBSD.