### PR TITLE
czinspect: clean up the configtest program

### DIFF
--- a/src/czinspect/tools/configtest.c
+++ b/src/czinspect/tools/configtest.c
@@ -1,8 +1,6 @@
-#include <err.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 /* simple config test program */
 


### PR DESCRIPTION
Minor cleanup to `src/czinspect/tools/configtest.c`, removing redundant header files.