### PR TITLE
czinspect: refactor dynamic data structures code.

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,7 +1,7 @@
 BSD 2-Clause License
 
 Copyright (c) 2018, Tom Harley
-Copyright (c) 2018, David Miller
+Copyright (c) 2018, 2019 Molly Miller
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -137,6 +137,6 @@ get_region -i "all-extracted" -l 3030 -u 2929 -r 3153 -d 3718 -o "my-region.png"
 
 ## Credits
 
-This code is actively developed by David Miller and Tom Harley,
+This code is actively developed by Molly Miller and Tom Harley,
 and is based on work by Calum Duff for a project with a team including
 Johannes Weck, Hafeez Abdul Rehaman and Josh Lee.

--- a/src/czinspect/Makefile
+++ b/src/czinspect/Makefile
@@ -10,7 +10,7 @@ CCOBJ = ${CCSRC:.c=.o}
 HEADERS = $(wildcard src/*.h) src/compat/compat.h
 OBJECTS = $(CCOBJ)
 
-CFLAGS += -std=c99 -Wall -Werror
+CFLAGS += -std=c99 -Wall -Wextra -Werror
 
 ifeq ($(strip $(BSD)),)
 CCSRC += $(wildcard src/compat/*.c)

--- a/src/czinspect/src/alloc.c
+++ b/src/czinspect/src/alloc.c
@@ -37,8 +37,8 @@ char *_xstrdup(const char *name, char *str) {
  * to avoid this call being optimised out */
 static void* (*volatile lzmemset)(void *, int, size_t) = memset;
 
-lzstring _lzstr_new(const char *name, size_t num, size_t sz) {
-    lzstring ret = malloc(sizeof(struct lzstring_s));
+lzstring *_lzstr_new(const char *name, size_t num, size_t sz) {
+    lzstring *ret = malloc(sizeof(struct lzstring_s));
     if (ret == NULL)
         nerr1(name, "could not allocate dynamic string");
 
@@ -46,51 +46,56 @@ lzstring _lzstr_new(const char *name, size_t num, size_t sz) {
     if (ret->data == NULL)
         nerr1(name, "could not allocate dynamic string");
 
-    ret->len = num * sz;
-    lzmemset(ret->data, 0, ret->len);
-
+    ret->alen = num * sz;
+    ret->len = 0;
+    lzmemset(ret->data, 0, ret->alen);
     return ret;
 }
 
-void _lzstr_zero(lzstring l) {
-    lzmemset(l->data, 0, l->len);
+void _lzstr_zero(lzstring *l) {
+    lzmemset(l->data, 0, l->alen);
+    l->len = 0;
 }
 
-void _lzstr_resize(const char *name, lzstring l, size_t num, size_t sz) {
+void _lzstr_resize(const char *name, lzstring *l, size_t num, size_t sz) {
     l->data = reallocarray(l->data, num, sz);
     if (l->data == NULL)
         nerr1(name, "could not resize dynamic string");
 
-    if (num * sz > l->len)
-        lzmemset(l->data + l->len, 0, (num * sz) - l->len);
+    if (num * sz > l->alen)
+        lzmemset(l->data + l->alen, 0, (num * sz) - l->alen);
 
-    l->len = num * sz;
-    
-    return;
+    l->alen = num * sz;
 }
 
-void _lzstr_free(lzstring l) {
+void _lzstr_free(lzstring *l) {
     free(l->data);
     free(l);
 
     return;
 }
 
-void _lzstr_cat(const char *name, lzstring l, char *ap) {
-    size_t llen = strlen(l->data);
-    size_t alen = strlen(ap);
+void _lzstr_setlen(const char *name, lzstring *l, size_t num, size_t sz) {
+    while (l->alen < num * sz)
+        _lzstr_resize(name, l, l->alen * 2, sz);
 
-    while (l->len < llen + alen + 1)
-        _lzstr_resize(name, l, l->len * 2, sizeof(char));
-
-    memcpy(&l->data[llen], ap, alen);
-    l->data[llen + alen] = '\0';
-
-    return;
+    l->len = num * sz;
 }
 
-/* lz{s,v}printf() implementation based on {v,}asprintf() in musl libc */
-int lzsprintf(lzstring l, const char *fmt, ...) {
+void _lzstr_cat(const char *name, lzstring *l, char *ap) {
+    /* corner case: either the target buffer is empty or it contains
+     * chars ended by a null byte. */
+    size_t llen = l->len == 0 ? 0 : l->len - 1;
+    size_t clen = strlen(ap) + 1; /* include null byte */
+
+    _lzstr_setlen(name, l, llen + clen, sizeof(char));
+
+    memcpy(&l->data[llen], ap, clen);
+    /* the string is not explicitly null-terminated here, the
+     * argument's null byte is included. */
+}
+
+int lzsprintf(lzstring *l, const char *fmt, ...) {
     int ret;
     va_list ap;
 
@@ -101,7 +106,7 @@ int lzsprintf(lzstring l, const char *fmt, ...) {
     return ret;
 }
 
-int lzvprintf(lzstring l, const char *fmt, va_list ap) {
+int lzvprintf(lzstring *l, const char *fmt, va_list ap) {
     int len;
     va_list ap2;
 
@@ -112,11 +117,7 @@ int lzvprintf(lzstring l, const char *fmt, va_list ap) {
     if (len < 0)
         return -1;
 
-    while (l->len < len + 1)
-        lzstr_grow(l);
+    lzstr_setlen(l, (size_t)len + 1);
 
-    return vsnprintf(l->data, len + 1, fmt, ap);
+    return vsnprintf(l->data, (size_t)len + 1, fmt, ap);
 }
-
-
-

--- a/src/czinspect/src/alloc.h
+++ b/src/czinspect/src/alloc.h
@@ -17,11 +17,12 @@ char *_xstrdup(const char *, char *);
 /* Lazily allocated string structure; inspired by djb's stralloc and
  * skarnet's genalloc */
 struct lzstring_s {
-    char *data;   /* pointer to data */
-    size_t len;   /* size of allocated data area */
+    char *data;    /* pointer to data */
+    size_t len;    /* number of bytes used in allocated data area */
+    size_t alen;   /* size of allocated data area */
 };
-typedef struct lzstring_s * lzstring;
-typedef lzstring lzbuf;
+typedef struct lzstring_s lzstring;
+typedef struct lzstring_s lzbuf;
 
 #define LZS_DEFAULT_LEN  40 /* default length of allocated strings */
 #define LZB_DEFAULT_LEN   8 /* default length of allocated buffer arrays */
@@ -39,18 +40,21 @@ typedef lzstring lzbuf;
 #define lzbuf_grow(type, b)    _lzstr_resize(__func__, b, (b)->len * 2, sizeof(type))
 
 #define lzstr_cat(l, s)        _lzstr_cat(__func__, l, s)
+#define lzstr_setlen(b, l)     _lzstr_setlen(__func__, b, l, sizeof(char))
+#define lzbuf_setlen(t, b, l)  _lzstr_setlen(__func__, b, l, sizeof(t))
 
 #define lzstr_free(s)          _lzstr_free(s)
 #define lzbuf_free(s)          _lzstr_free(s)
 
-lzstring _lzstr_new(const char *, size_t, size_t);
-void _lzstr_zero(lzstring);
-void _lzstr_resize(const char *, lzstring, size_t, size_t);
-void _lzstr_free(lzstring);
+lzstring *_lzstr_new(const char *, size_t, size_t);
+void _lzstr_zero(lzstring *);
+void _lzstr_resize(const char *, lzstring *, size_t, size_t);
+void _lzstr_setlen(const char *, lzstring *, size_t, size_t);
+void _lzstr_free(lzstring *);
 
-void _lzstr_cat(const char *, lzstring, char *);
+void _lzstr_cat(const char *, lzstring* , char *);
 
-int lzsprintf(lzstring, const char *, ...);
-int lzvprintf(lzstring, const char *, va_list);
+int lzsprintf(lzstring *, const char *, ...);
+int lzvprintf(lzstring *, const char *, va_list);
 
 #endif /* _ALLOC_H */

--- a/src/czinspect/src/czinspect.c
+++ b/src/czinspect/src/czinspect.c
@@ -203,7 +203,7 @@ static void parse_opt_check(int opt) {
 static void check_ops() {
     uint8_t num = 0;
 
-    for (int i = 0; i < sizeof(uint8_t) * 8; i++)
+    for (int i = 0; i < (int)sizeof(uint8_t) * 8; i++)
         num += (cfg.operation >> i) % 2;
 
     if (num > 1)

--- a/src/czinspect/src/czinspect.c
+++ b/src/czinspect/src/czinspect.c
@@ -1,7 +1,7 @@
 /*
  * Carl Zeiss CZI file format inspection utility.
  *
- * Written by David Miller, based on prior programs written by David Miller and
+ * Written by Molly Miller, based on prior programs written by David Miller and
  * Callum Duff.
  */
 

--- a/src/czinspect/src/mapfile.c
+++ b/src/czinspect/src/mapfile.c
@@ -39,8 +39,11 @@ static size_t def_chunklen;
 
 /* configure memory-mapped file code */
 int map_configure(struct config *cfg) {
-    if ((page_size = sysconf(_SC_PAGESIZE)) == -1)
+    long sysconf_pagesize = sysconf(_SC_PAGESIZE);
+    if (sysconf_pagesize == -1)
         return 0;
+
+    page_size = (size_t) sysconf_pagesize;
     
     if (cfg->page_multiplier != 0)
         def_chunklen = cfg->page_multiplier * page_size;

--- a/src/czinspect/src/operations.c
+++ b/src/czinspect/src/operations.c
@@ -4,9 +4,11 @@
 #include "types.h"
 
 void do_dump(struct config *cfg) {
+    (void) cfg;
     return;
 }
 
 void do_check(struct config *cfg) {
+    (void) cfg;
     return;
 }

--- a/src/czinspect/src/scan.c
+++ b/src/czinspect/src/scan.c
@@ -24,8 +24,7 @@ void do_scan(struct config *cfg) {
     struct czi_seg_header head;
     struct czi_zrf zisrf;
     struct map_ctx *c;
-    lzbuf reslist;
-    uint32_t rnum = 0;
+    lzbuf *reslist;
 
     parse_opts(cfg);
 
@@ -50,12 +49,12 @@ void do_scan(struct config *cfg) {
 
     reslist = lzbuf_new(uint32_t);
 
-    if (make_reslist(c, reslist, &rnum) == -1)
+    if (make_reslist(c, reslist) == -1)
         ferrx1("could not scan for subsampling levels in input file");
 
     printf("Available subsampling levels (smaller number indicates higher resolution):\n\n");
 
-    for (uint32_t i = 0; i < rnum; i++)
+    for (uint32_t i = 0; i < lzbuf_elems(uint32_t, reslist); i++)
         printf("\t%" PRIu32 "\n", lzbuf_get(uint32_t, reslist, i));
 
     printf("\n");

--- a/src/czinspect/src/util.h
+++ b/src/czinspect/src/util.h
@@ -10,7 +10,7 @@
 
 int xfallocate(int, size_t);
 
-uint32_t get_subsample_level(lzbuf, uint32_t);
-int make_reslist(struct map_ctx *, lzbuf, uint32_t *);
+uint32_t get_subsample_level(lzbuf *);
+int make_reslist(struct map_ctx *, lzbuf *);
 
 #endif /* _UTIL_H */


### PR DESCRIPTION
The dynamic data structure handling code now stores the number of items in a buffer (or number of characters in a string) as book-keeping information within the structure alongside the size of the actual allocated area. This makes some of the code around scanning for subsampling levels a little tidier and removes the needs for passing length parameters to multiple places. I've also added the `-Wextra` compiler flag to `czinspect` (which caught a few implicit casts which look to be otherwise safe; hopefully this won't break any CI things) and fixed copyright years for my attributions.

This should fix #10.